### PR TITLE
fix(docs): correct boolean input default value in workflow_dispatch

### DIFF
--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       importAll:
-        default: 'false'
+        default: false
         required: false
         type: boolean
         description: Enable, if you want to import all TODOs. Runs on checked out branch! Only use if you're sure what you are doing.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ on:
   workflow_dispatch:
     inputs:
       importAll:
-        default: 'false'
+        default: false
         required: false
         type: boolean
         description: Enable, if you want to import all TODOs. Runs on checked out branch! Only use if you're sure what you are doing.


### PR DESCRIPTION
## Description
When using the example workflow, linting raised an error. Specifically, the problem arises with the boolean default in the workflow_dispatch event. 

## Context
The error message is as follows:

```
Unexpected type 'StringToken' encountered while reading 'input default'. The type 'BooleanToken' was expected.
```

This is the section of code impacted:

https://github.com/Juulsn/todo-issue/blob/8c097a4b0b3f72dcda9591c96bf116a8b3e0928c/README.md?plain=1#L47-L56

This is because the default value for the importAll input was set to 'false', which is a string rather than a boolean. Removing the single quotes sets the default variable as a boolean. 